### PR TITLE
feat: 게시판 이미지 업로드시 클라우디너리에 저장

### DIFF
--- a/todayCody/frontend/src/api/auth.js
+++ b/todayCody/frontend/src/api/auth.js
@@ -99,6 +99,7 @@ export const getMyFeeds = async (user_seq) => {
     const res = await axios.get(
       `${baseUrl}/myPage/list.do?user_seq=${user_seq}`
     );
+    console.log(res.data);
     return res.data.list;
   } catch (err) {
     if (err.response.status === 404) {

--- a/todayCody/frontend/src/api/board.js
+++ b/todayCody/frontend/src/api/board.js
@@ -3,19 +3,26 @@ import axios from "axios";
 const baseUrl = "http://52.79.65.236:8081";
 
 export const uploadBoard = async (formData, navigate) => {
-  const res = await axios.post(`${baseUrl}/board/write.do`, formData);
+  try {
+    const res = await axios.post(`${baseUrl}/board/write.do`, formData);
 
-  if (res.status === 200) {
-    window.alert("피드 업로드 성공!");
-    return res;
-    //navigate("/board");
+    if (res.data.retCode === "000") {
+      window.alert("게시물 업로드 성공!");
+      navigate("/board");
+      return res;
+    } else {
+      window.alert("업로드 중 문제가 생겼습니다.");
+    }
+  } catch (err) {
+    console.log(err);
   }
 };
 
-export const getBoard = async () => {
-  const res = await axios.get(`${baseUrl}/board/list.do?page_num=1`);
-
-  if (res.status === 200) {
-    console.log(res);
+export const getBoard = async (params) => {
+  try {
+    const res = await axios.post(`${baseUrl}/board/list.do`, params);
+    return res;
+  } catch (err) {
+    console.log(err);
   }
 };

--- a/todayCody/frontend/src/api/feed.js
+++ b/todayCody/frontend/src/api/feed.js
@@ -6,7 +6,8 @@ const baseUrl = "http://52.79.65.236:8081";
 export const feedUpload = async (formData, navigate) => {
   try {
     const res = await axios.post(`${baseUrl}/feed/write.do`, formData);
-    if (res.status === 200) {
+    console.log(res);
+    if (res.data.retCode === "000") {
       window.alert("피드 업로드 성공!");
       navigate("/mypage");
     } else {
@@ -22,7 +23,7 @@ export function useGetFeeds() {
   const [feeds, setFeeds] = useState();
   useEffect(() => {
     axios({
-      url: `${baseUrl}/feed/list.do?&per_page=12&page=1`,
+      url: `${baseUrl}/feed/list.do?per_page=12&page=1`,
       method: "get",
     })
       .then((res) => {
@@ -40,7 +41,7 @@ export function useGetFeeds() {
 //쿼리 함수
 export const getFeeds = async () => {
   try {
-    const res = await axios.get(`${baseUrl}/feed/list.do`);
+    const res = await axios.get(`${baseUrl}/feed/list.do?page=&per_page=12`);
     const reverse = [...res.data.list].reverse();
     return reverse;
   } catch (err) {
@@ -50,9 +51,4 @@ export const getFeeds = async () => {
       alert("서버에 문제가 있습니다.");
     }
   }
-};
-
-export const uploadFeed = async (formData) => {
-  const res = await axios.post(`${baseUrl}/feed/write.do`, formData);
-  return res;
 };

--- a/todayCody/frontend/src/components/layout/Header.jsx
+++ b/todayCody/frontend/src/components/layout/Header.jsx
@@ -17,9 +17,8 @@ export default function Header() {
     localStorage.removeItem("expiration");
     navigate("/");
   };
-
   console.log(user);
-  console.log(token, username);
+
   return (
     <>
       <header>

--- a/todayCody/frontend/src/contexts/AuthContext.jsx
+++ b/todayCody/frontend/src/contexts/AuthContext.jsx
@@ -1,32 +1,29 @@
 import { createContext, useReducer } from "react";
+import { useEffect, useState } from "react";
+import { getMyData } from "api/auth";
 
 const INITIAL_STATE = {
-  user: null,
   username: localStorage.getItem("username") || null,
 };
 
-export const AuthContext = createContext(INITIAL_STATE);
+export const AuthContext = createContext();
 
 const AuthReducer = (state, action) => {
   switch (action.type) {
     case "LOGIN_START":
       return {
-        user: null,
         username: null,
       };
     case "LOGIN_SUCCESS":
       return {
-        user: action.payload.user,
         username: action.payload.username,
       };
     case "LOGIN_FAILURE":
       return {
-        user: null,
         username: null,
       };
     case "LOGOUT":
       return {
-        user: null,
         username: null,
       };
     default:
@@ -36,15 +33,17 @@ const AuthReducer = (state, action) => {
 
 export function AuthContextProvider({ children }) {
   const [state, dispatch] = useReducer(AuthReducer, INITIAL_STATE);
+  const [user, setUser] = useState({});
+  const token = localStorage.getItem("token");
 
-  // useEffect(() => {
-  //   getMyData(token).then((res) => setUser(res));
-  // }, [token]);
+  useEffect(() => {
+    getMyData(token).then((res) => setUser(res));
+  }, [token]);
 
   return (
     <AuthContext.Provider
       value={{
-        user: state.user,
+        user: user,
         username: state.username,
         dispatch,
       }}

--- a/todayCody/frontend/src/pages/Board.jsx
+++ b/todayCody/frontend/src/pages/Board.jsx
@@ -14,6 +14,7 @@ export default function Board() {
   };
   const [currentPage, setCurrentPage] = useState(1);
   const postsPerPage = selected === "free" ? 10 : 12;
+  getBoard({ page_num: "1", max_ret_cnt: "5", type: 1 });
 
   const lastPostIndex = currentPage * postsPerPage;
   const firstPostIndex = lastPostIndex - postsPerPage;

--- a/todayCody/frontend/src/pages/MyPage.jsx
+++ b/todayCody/frontend/src/pages/MyPage.jsx
@@ -61,17 +61,7 @@ export default function MyPage() {
             </div>
             <div className="bottom">
               <p>안녕하세요리사 오늘코디화이팅</p>
-              <button
-                onClick={() =>
-                  navigate("/newboard", {
-                    state: {
-                      type: 1,
-                    },
-                  })
-                }
-              >
-                글 작성
-              </button>
+              <button onClick={() => navigate("/newpost")}>글 작성</button>
             </div>
           </div>
         </div>

--- a/todayCody/frontend/src/pages/NewPost.jsx
+++ b/todayCody/frontend/src/pages/NewPost.jsx
@@ -7,12 +7,12 @@ import { BsCheckLg } from "react-icons/bs";
 import { useMutation } from "@tanstack/react-query";
 
 export default function NewPost() {
-  const user = useContext(AuthContext);
+  const { user } = useContext(AuthContext);
   const navigate = useNavigate();
 
   let formData = new FormData();
   const mutation = useMutation({
-    mutationFn: (formData, navigate) => feedUpload(formData, navigate),
+    mutationFn: (formData) => feedUpload(formData, navigate),
   });
 
   const [selectedFiles, setSelectedFiles] = useState([]);
@@ -49,6 +49,8 @@ export default function NewPost() {
         content: feedContent,
         file: fileDataArray,
       };
+
+      console.log(feedData);
 
       formData.append("jsonData", JSON.stringify(feedData));
       //mutaion 사용 전 코드

--- a/todayCody/frontend/src/pages/SignIn.jsx
+++ b/todayCody/frontend/src/pages/SignIn.jsx
@@ -22,6 +22,7 @@ export default function Login() {
     try {
       const res = await axios.post(`${baseUrl}/member/signIn.do`, inputData);
       navigate("/");
+      console.log(res);
 
       dispatch({
         type: "LOGIN_SUCCESS",


### PR DESCRIPTION
quill에서 이미지 업로드하려면 백엔드에 이미지 업로드하고 url을 받아와서 quill에디터에 보여줘야 하는데 이미지만 올리는 api가 없어서 제 클라우디너리 계정에 올리고 url 받아와서 quill에서 볼 수 있게 해놨습니다. 